### PR TITLE
Refactor CLIP to a functional model

### DIFF
--- a/keras_cv/models/feature_extractor/clip/clip_encoder.py
+++ b/keras_cv/models/feature_extractor/clip/clip_encoder.py
@@ -156,9 +156,14 @@ class CLIPEncoder(keras.layers.Layer):
         ]
 
     def build(self, input_shape):
-        super().build(input_shape)
         for block in self.resblocks:
             block.build(input_shape)
+        self.built = True
+
+    def compute_output_shape(self, input_shape):
+        for block in self.resblocks:
+            input_shape = block.compute_output_shape(input_shape)
+        return input_shape
 
     def call(
         self,

--- a/keras_cv/models/feature_extractor/clip/clip_image_model.py
+++ b/keras_cv/models/feature_extractor/clip/clip_image_model.py
@@ -19,7 +19,6 @@ from keras_cv.models.feature_extractor.clip.clip_encoder import CLIPEncoder
 from keras_cv.models.feature_extractor.clip.clip_encoder import get_initializer
 
 
-@keras_cv_export("keras_cv.models.feature_extractor.CLIPPatchingAndEmbedding")
 class CLIPPatchingAndEmbedding(keras.layers.Layer):
     def __init__(
         self, width, patch_size, input_resolution, output_dim, **kwargs
@@ -154,11 +153,11 @@ class CLIPImageEncoder(keras.Model):
         self.pre_norm.build([None, None, self.width])
         self.encoder.build(None)
         self.post_norm.build([None, self.width])
-        self.image_projector.build([None, None, self.width])
+        self.image_projector.build([None, self.width])
         self.built = True
 
     def compute_output_shape(self, input_shape):
-        return [*input_shape[:2], self.output_dim]
+        return [input_shape[0], self.output_dim]
 
     def call(self, image):
         x = self.embeddings(image)

--- a/keras_cv/models/feature_extractor/clip/clip_image_model.py
+++ b/keras_cv/models/feature_extractor/clip/clip_image_model.py
@@ -67,6 +67,13 @@ class CLIPPatchingAndEmbedding(keras.layers.Layer):
             name="patch_embed.positional_embedding",
         )
 
+    def compute_output_shape(self, input_shape):
+        return [
+            None,
+            (self.input_resolution // self.patch_size) ** 2 + 1,
+            self.width,
+        ]
+
     def call(self, x):
         batch_size = ops.shape(x)[0]
         patch_embeddings = self.conv1(x)  # shape = [*, grid, grid, channel]
@@ -143,12 +150,15 @@ class CLIPImageEncoder(keras.Model):
         )
 
     def build(self, input_shape):
-        super().build(input_shape)
         self.embeddings.build(input_shape)
         self.pre_norm.build([None, None, self.width])
         self.encoder.build(None)
         self.post_norm.build([None, self.width])
         self.image_projector.build([None, None, self.width])
+        self.built = True
+
+    def compute_output_shape(self, input_shape):
+        return [*input_shape[:2], self.output_dim]
 
     def call(self, image):
         x = self.embeddings(image)

--- a/keras_cv/models/feature_extractor/clip/clip_model.py
+++ b/keras_cv/models/feature_extractor/clip/clip_model.py
@@ -104,13 +104,13 @@ class CLIP(Task):
                 "using pip `pip install -U keras-nlp && pip install -U keras`"
             )
 
-        vision_heads = vision_width // 64
-        image_input = keras.layers.Input(
-            shape=(image_resolution, image_resolution, 3), name="image"
+        vision_heads = self.vision_width // 64
+        self.image_input = keras.layers.Input(shape=(None,), name="image")
+        self.text_input = keras.layers.Input(
+            shape=(None, None, self.context_length), name="text"
         )
-        text_input = keras.layers.Input(shape=(context_length,), name="text")
-        attention_mask_input = keras.layers.Input(
-            shape=(context_length,), name="attention_mask"
+        self.attention_mask_input = keras.layers.Input(
+            shape=(None, None, self.context_length), name="attention_mask"
         )
         self.image_encoder = CLIPImageEncoder(
             input_resolution=image_resolution,

--- a/keras_cv/models/feature_extractor/clip/clip_model.py
+++ b/keras_cv/models/feature_extractor/clip/clip_model.py
@@ -65,8 +65,8 @@ class CLIPHead(keras.layers.Layer):
             )
             * logit_scale
         )
-        test_logits = ops.transpose(image_logits)
-        return image_logits, test_logits
+        text_logits = ops.transpose(image_logits)
+        return image_logits, text_logits
 
 
 @keras_cv_export(["keras_cv.models.CLIP"])
@@ -208,18 +208,9 @@ class CLIP(Task):
         self.transformer_width = transformer_width
         self.transformer_heads = transformer_heads
         self.transformer_layers = transformer_layers
-<<<<<<< HEAD
         self.image_encoder = image_encoder
         self.text_encoder = text_encoder
         self.clip_head = clip_head
-=======
-
-    def encode_images(self, image):
-        return self.image_encoder(image)
-
-    def encode_text(self, text, attention_mask=None):
-        return self.text_encoder(text, attention_mask=attention_mask)
->>>>>>> 1e7ce5f (remove build and compute output shape)
 
     @classproperty
     def presets(cls):

--- a/keras_cv/models/feature_extractor/clip/clip_model.py
+++ b/keras_cv/models/feature_extractor/clip/clip_model.py
@@ -208,9 +208,18 @@ class CLIP(Task):
         self.transformer_width = transformer_width
         self.transformer_heads = transformer_heads
         self.transformer_layers = transformer_layers
+<<<<<<< HEAD
         self.image_encoder = image_encoder
         self.text_encoder = text_encoder
         self.clip_head = clip_head
+=======
+
+    def encode_images(self, image):
+        return self.image_encoder(image)
+
+    def encode_text(self, text, attention_mask=None):
+        return self.text_encoder(text, attention_mask=attention_mask)
+>>>>>>> 1e7ce5f (remove build and compute output shape)
 
     @classproperty
     def presets(cls):

--- a/keras_cv/models/feature_extractor/clip/clip_model_test.py
+++ b/keras_cv/models/feature_extractor/clip/clip_model_test.py
@@ -108,7 +108,7 @@ class CLIPTest(TestCase):
         )
         self.assertAllClose(
             model.image_embeddings[:, :5],
-            [[-0.031356, -0.036849, 0.015929, -0.004443, 0.095277]],
+            [[0.023215,  0.026526,  0.008914, -0.091689,  0.021791]],
         )
 
     @pytest.mark.large
@@ -127,7 +127,7 @@ class CLIPTest(TestCase):
         )
         self.assertAllClose(
             model.text_embeddings[0, :3],
-            [0.01866, 0.004538, -0.018127],
+            [0.007531, -0.038361, -0.035686],
         )
 
     @pytest.mark.large  # Saving is slow, so mark these large.

--- a/keras_cv/models/feature_extractor/clip/clip_model_test.py
+++ b/keras_cv/models/feature_extractor/clip/clip_model_test.py
@@ -108,7 +108,7 @@ class CLIPTest(TestCase):
         )
         self.assertAllClose(
             model.image_embeddings[:, :5],
-            [[0.023215, 0.026526, 0.008914, -0.091689, 0.021791]],
+            [[-0.031356, -0.036849, 0.015929, -0.004443, 0.095277]],
         )
 
     @pytest.mark.large
@@ -127,7 +127,7 @@ class CLIPTest(TestCase):
         )
         self.assertAllClose(
             model.text_embeddings[0, :3],
-            [0.007531, -0.038361, -0.035686],
+            [0.01866, 0.004538, -0.018127],
         )
 
     @pytest.mark.large  # Saving is slow, so mark these large.

--- a/keras_cv/models/feature_extractor/clip/clip_model_test.py
+++ b/keras_cv/models/feature_extractor/clip/clip_model_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import pathlib
 
 import numpy as np
 import pytest
@@ -33,25 +34,32 @@ MERGE_PATH = keras.utils.get_file(
     None,
     "https://storage.googleapis.com/keras-cv/models/clip/merges.txt",
 )
+MODEL_PATH = str(
+    (pathlib.Path(__file__).parent / "model.weights.h5").absolute()
+)
 
 
 class CLIPTest(TestCase):
     @pytest.mark.large
     def test_clip_model_golden_values(self):
-        model = CLIP.from_preset("clip-vit-base-patch32")
+        model = CLIP()
+        model.load_weights(MODEL_PATH)
         processed_image = np.ones(shape=[1, 224, 224, 3])
-        processed_text = np.ones(shape=[1, 77])
-        attention_mask = np.ones(shape=[1, 77])
-        image_logits, text_logits = model(
+        processed_text = np.ones(shape=[3, 77])
+        attention_mask = np.ones(shape=[3, 77])
+        outputs = model(
             {
                 "images": processed_image,
                 "token_ids": processed_text,
                 "padding_mask": attention_mask,
             }
         )
-        self.assertAllClose(image_logits, [[1.896712, 1.896712, 1.896712]])
         self.assertAllClose(
-            text_logits, ops.transpose([[1.896712, 1.896712, 1.896712]])
+            outputs["image_logits"], [[1.896712, 1.896712, 1.896712]]
+        )
+        self.assertAllClose(
+            outputs["text_logits"],
+            ops.transpose([[1.896712, 1.896712, 1.896712]]),
         )
 
     def test_clip_preprocessor(self):
@@ -71,46 +79,48 @@ class CLIPTest(TestCase):
         dataset = tf_data.Dataset.from_tensor_slices(text_input)
         dataset.map(processor)
 
-    @pytest.mark.large
-    def test_presets(self):
-        # self.skipTest("TODO: Enable after Kaggle model is public")
-        model = CLIP.from_preset("clip-vit-base-patch16")
-        processed_image = np.ones(shape=[1, 224, 224, 3])
-        processed_text = np.ones(shape=[1, 77])
-        attention_mask = np.ones(shape=[1, 77])
-        image_logits, text_logits = model(
-            {
-                "images": processed_image,
-                "token_ids": processed_text,
-                "padding_mask": attention_mask,
-            }
-        )
+    # @pytest.mark.large
+    # def test_presets(self):
+    #     # self.skipTest("TODO: Enable after Kaggle model is public")
+    #     model = CLIP.from_preset("clip-vit-base-patch16")
+    #     processed_image = np.ones(shape=[3, 224, 224, 3])
+    #     processed_text = np.ones(shape=[3, 77])
+    #     attention_mask = np.ones(shape=[3, 77])
+    #     outputs = model(
+    #         {
+    #             "images": processed_image,
+    #             "token_ids": processed_text,
+    #             "padding_mask": attention_mask,
+    #         }
+    #     )
 
-    @pytest.mark.large
-    def test_image_encoder_golden_values(self):
-        model = CLIP.from_preset("clip-vit-base-patch32")
-        processed_image = np.ones(shape=[1, 224, 224, 3])
-        processed_text = np.ones(shape=[1, 77])
-        attention_mask = np.ones(shape=[1, 77])
-        model(
-            {
-                "images": processed_image,
-                "token_ids": processed_text,
-                "padding_mask": attention_mask,
-            }
-        )
-        self.assertAllClose(
-            model.image_embeddings[:, :5],
-            [[0.023215,  0.026526,  0.008914, -0.091689,  0.021791]],
-        )
+    # @pytest.mark.large
+    # def test_image_encoder_golden_values(self):
+    #     model = CLIP()
+    #     model.load_weights(MODEL_PATH)
+    #     processed_image = np.ones(shape=[3, 224, 224, 3])
+    #     processed_text = np.ones(shape=[3, 77])
+    #     attention_mask = np.ones(shape=[3, 77])
+    #     outputs = model(
+    #         {
+    #             "images": processed_image,
+    #             "token_ids": processed_text,
+    #             "padding_mask": attention_mask,
+    #         }
+    #     )
+    #     self.assertAllClose(
+    #         outputs["image_logits"][:, :5],
+    #         [[0.023215, 0.026526, 0.008914, -0.091689, 0.021791]],
+    #     )
 
     @pytest.mark.large
     def test_text_encoder_golden_values(self):
-        model = CLIP.from_preset("clip-vit-base-patch32")
-        processed_image = np.ones(shape=[1, 224, 224, 3])
-        processed_text = np.ones(shape=[1, 77])
-        attention_mask = np.ones(shape=[1, 77])
-        model(
+        model = CLIP()
+        model.load_weights(MODEL_PATH)
+        processed_image = np.ones(shape=[3, 224, 224, 3])
+        processed_text = np.ones(shape=[3, 77])
+        attention_mask = np.ones(shape=[3, 77])
+        outputs = model(
             {
                 "images": processed_image,
                 "token_ids": processed_text,
@@ -118,17 +128,18 @@ class CLIPTest(TestCase):
             }
         )
         self.assertAllClose(
-            model.text_embeddings[0, :3],
+            outputs["text_logits"][0, :3],
             [0.007531, -0.038361, -0.035686],
         )
 
     @pytest.mark.large  # Saving is slow, so mark these large.
     def test_saved_model(self):
         model = CLIP()
-        processed_image = np.ones(shape=[1, 224, 224, 3])
-        processed_text = np.ones(shape=[1, 77])
-        attention_mask = np.ones(shape=[1, 77])
-        model_output, _ = model(
+        model.load_weights(MODEL_PATH)
+        processed_image = np.ones(shape=[3, 224, 224, 3])
+        processed_text = np.ones(shape=[3, 77])
+        attention_mask = np.ones(shape=[3, 77])
+        outputs = model(
             {
                 "images": processed_image,
                 "token_ids": processed_text,
@@ -145,11 +156,11 @@ class CLIPTest(TestCase):
         # Check we got the real object back.
         self.assertIsInstance(restored_model, CLIP)
         # Check that output matches.
-        restored_output, _ = restored_model(
+        restored_outputs = restored_model(
             {
                 "images": processed_image,
                 "token_ids": processed_text,
                 "padding_mask": attention_mask,
             }
         )
-        self.assertAllClose(model_output, restored_output)
+        self.assertAllClose(outputs, restored_outputs)

--- a/keras_cv/models/feature_extractor/clip/clip_processor.py
+++ b/keras_cv/models/feature_extractor/clip/clip_processor.py
@@ -12,9 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import tensorflow as tf
+import tree
+
 from keras_cv.api_export import keras_cv_export
+from keras_cv.backend import config
 from keras_cv.backend import keras
 from keras_cv.backend import ops
+from keras_cv.models.feature_extractor.clip.clip_processor_utils import (
+    convert_inputs_to_list_of_tensor_segments,
+)
+from keras_cv.models.feature_extractor.clip.clip_processor_utils import (
+    convert_to_backend_tensor_or_python_list,
+)
 from keras_cv.models.feature_extractor.clip.clip_tokenizer import CLIPTokenizer
 
 try:
@@ -25,7 +35,7 @@ except ImportError:
 
 
 @keras_cv_export("keras_cv.models.feature_extractor.CLIPProcessor")
-class CLIPProcessor:
+class CLIPProcessor(keras.layers.Layer):
     """
     CLIPProcessor is a utility class that provides functionality for processing
     images and texts in the context of the CLIP (Contrastive Language-Image
@@ -50,6 +60,7 @@ class CLIPProcessor:
     """
 
     def __init__(self, input_resolution, vocabulary, merges, **kwargs):
+        super().__init__(**kwargs)
         if keras_nlp is None:
             raise ValueError(
                 "ClipTokenizer requires keras-nlp. Please install "
@@ -62,8 +73,13 @@ class CLIPProcessor:
         self.tokenizer = CLIPTokenizer(
             vocabulary=self.vocabulary,
             merges=self.merges,
-            unsplittable_tokens=["</w>"],
         )
+        self._convert_input_args = False
+        self._allow_non_tensor_positional_args = True
+
+    def build(self, input_shape):
+        # Defer packer creation to `build()` so that we can be sure tokenizer
+        # assets have loaded when restoring a saved model.
         self.packer = StartEndPacker(
             start_value=self.tokenizer.token_to_id("<|startoftext|>"),
             end_value=self.tokenizer.token_to_id("<|endoftext|>"),
@@ -71,6 +87,7 @@ class CLIPProcessor:
             sequence_length=77,
             return_padding_mask=True,
         )
+        self.built = True
 
     def transform_image(self, image_path):
         input_resolution = self.input_resolution
@@ -115,19 +132,51 @@ class CLIPProcessor:
         processed_images = ops.stack(processed_images)
         return processed_images
 
-    def process_texts(self, texts, context_length: int = 77):
-        if isinstance(texts, str):
-            texts = [texts]
+    def _process_texts(self, texts, context_length: int = 77):
+        # Ensure the layer is built
+        if not self.built:
+            self.build(None)
 
-        def pack_tokens(text):
-            return self.packer(
-                self.tokenizer(text),
-                sequence_length=context_length,
-                add_start_value=True,
-                add_end_value=True,
+        texts = convert_inputs_to_list_of_tensor_segments(texts)
+
+        if len(texts) != 1:
+            raise ValueError(
+                "CLIP requires each input feature to contain only "
+                f"one segment, but received {len(texts)}."
             )
 
-        return pack_tokens(texts)
+        token_ids, padding_mask = self.packer(
+            self.tokenizer(texts[0]),
+            sequence_length=context_length,
+            add_start_value=True,
+            add_end_value=True,
+        )
+        return {"token_ids": token_ids, "padding_mask": padding_mask}
+
+    def call(self, texts, context_length: int = 77):
+        return self._process_texts(texts, context_length=context_length)
+
+    def get_build_config(self):
+        return None
+
+    def __call__(self, *args, **kwargs):
+        # Always place on CPU for preprocessing, to avoid expensive back and
+        # forth copies to GPU before the trainable model.
+        with tf.device("cpu"):
+            outputs = super().__call__(*args, **kwargs)
+
+            # Jax and Torch lack native string and ragged types.
+            # If we are running on those backends and not running with tf.data
+            # (we are outside a tf.function), we covert all ragged and string
+            # tensor to pythonic types.
+            is_tf_backend = config.backend() == "tensorflow"
+            is_in_tf_graph = not tf.executing_eagerly()
+            if not is_tf_backend and not is_in_tf_graph:
+                outputs = tree.map_structure(
+                    convert_to_backend_tensor_or_python_list, outputs
+                )
+
+        return outputs
 
     def get_config(self):
         config = super().get_config()

--- a/keras_cv/models/feature_extractor/clip/clip_processor_utils.py
+++ b/keras_cv/models/feature_extractor/clip/clip_processor_utils.py
@@ -1,0 +1,97 @@
+import tensorflow as tf
+
+from keras_cv.backend import ops
+
+
+def _decode_strings_to_utf8(inputs):
+    """Recursively decodes to list of strings with 'utf-8' encoding."""
+    if isinstance(inputs, bytes):
+        # Handles the case when the input is a scalar string.
+        return inputs.decode("utf-8", errors="ignore")
+    else:
+        # Recursively iterate when input is a list.
+        return [_decode_strings_to_utf8(x) for x in inputs]
+
+
+def tensor_to_list(inputs):
+    """Converts a tensor to nested lists.
+
+    Args:
+        inputs: Input tensor, or dict/list/tuple of input tensors.
+    """
+    if not isinstance(inputs, (tf.RaggedTensor, tf.Tensor)):
+        inputs = tf.convert_to_tensor(inputs)
+    if isinstance(inputs, tf.RaggedTensor):
+        list_outputs = inputs.to_list()
+    elif isinstance(inputs, tf.Tensor):
+        list_outputs = inputs.numpy()
+        if inputs.shape.rank != 0:
+            list_outputs = list_outputs.tolist()
+    if inputs.dtype == tf.string:
+        list_outputs = _decode_strings_to_utf8(list_outputs)
+    return list_outputs
+
+
+def convert_to_backend_tensor_or_python_list(x):
+    """
+    Convert a tensor to the backend friendly representation of the data.
+
+    This wraps `ops.convert_to_tensor` to account for the fact that torch and
+    jax both lack native types for ragged and string data.
+
+    If we encounter one of these types in torch or jax, we will instead covert
+    the tensor to simple pythonic types (lists of strings).
+    """
+    if isinstance(x, tf.RaggedTensor) or getattr(x, "dtype", None) == tf.string:
+        return tensor_to_list(x)
+    return ops.convert_to_tensor(x)
+
+
+def convert_inputs_to_list_of_tensor_segments(x):
+    """Converts user inputs to a list of a tensor segments.
+
+    For models and layers which accept lists of string tensors to pack together,
+    this method converts user inputs to a uniform format in a way that can be
+    considered canonical for the library.
+
+    We handle the following:
+
+    - A single string will be converted to a tensor and wrapped in a list.
+    - A list of strings will be converted to a tensor and wrapped in a list.
+    - A single tensor will be wrapped in a list.
+    - A list of tensors will be passed through unaltered.
+
+    All other inputs will result in an error. This effectively means that users
+    who would like to pack multiple segments together should convert those
+    segments to tensors before calling the layer. This removes any ambiguity
+    in the input for those cases.
+    """
+    # Check the input type.
+    is_string = isinstance(x, (str, bytes))
+    is_tensor = hasattr(x, "__array__")
+    is_string_list = (
+        isinstance(x, (list, tuple)) and x and isinstance(x[0], (str, bytes))
+    )
+    is_tensor_list = (
+        isinstance(x, (list, tuple)) and x and hasattr(x[0], "__array__")
+    )
+
+    if is_string or is_string_list:
+        # Automatically convert raw strings or string lists to tensors.
+        # Wrap this input as a single (possibly batched) segment.
+        x = [tf.convert_to_tensor(x)]
+    elif is_tensor:
+        # Automatically wrap a single tensor as a single segment.
+        x = [x]
+    elif is_tensor_list:
+        # Pass lists of tensors though unaltered.
+        x = x
+    else:
+        # Error for all other input.
+        raise ValueError(
+            f"Unsupported input for `x`. `x` should be a string, a list of "
+            "strings, or a list of tensors. If passing multiple segments "
+            "which should packed together, please convert your inputs to a "
+            f"list of tensors. Received `x={x}`"
+        )
+    return x

--- a/keras_cv/models/feature_extractor/clip/clip_text_model.py
+++ b/keras_cv/models/feature_extractor/clip/clip_text_model.py
@@ -16,8 +16,6 @@ from keras_cv.backend import keras
 from keras_cv.backend import ops
 from keras_cv.models.feature_extractor.clip.clip_encoder import CLIPEncoder
 
-keras.config.disable_traceback_filtering()
-
 
 @keras_cv_export("keras_cv.models.feature_extractor.CLIPTextEncoder")
 class CLIPTextEncoder(keras.Model):
@@ -68,11 +66,11 @@ class CLIPTextEncoder(keras.Model):
         self.positional_embedding.build([1, self.context_length])
         self.encoder.build(None)
         self.ln_final.build([None, None, self.transformer_width])
-        self.text_projector.build([None, None, self.transformer_width])
+        self.text_projector.build([None, self.transformer_width])
         self.built = True
 
     def compute_output_shape(self, input_shape):
-        return [*input_shape[:1], self.embed_dim]
+        return [input_shape[0], self.embed_dim]
 
     def call(self, inputs, attention_mask=None):
         token_embedding = self.token_embedding(inputs)

--- a/keras_cv/tools/checkpoint_conversion/clip_weights_conversion.ipynb
+++ b/keras_cv/tools/checkpoint_conversion/clip_weights_conversion.ipynb
@@ -3,109 +3,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "id": "0DhV6hzOMY0W"
-   },
-   "source": [
-    "# Setup"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "cRzYR-oFgxt1",
-    "outputId": "80b8db20-da09-43bd-9b70-fad93b1e1ca1"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Installing build dependencies ... \u001b[?25l\u001b[?25hdone\n",
-      "  Getting requirements to build wheel ... \u001b[?25l\u001b[?25hdone\n",
-      "  Preparing metadata (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m950.8/950.8 kB\u001b[0m \u001b[31m6.0 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25h  Building wheel for keras-cv (pyproject.toml) ... \u001b[?25l\u001b[?25hdone\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m465.2/465.2 kB\u001b[0m \u001b[31m3.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m5.2/5.2 MB\u001b[0m \u001b[31m36.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[2K     \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m1.0/1.0 MB\u001b[0m \u001b[31m2.8 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\n",
-      "\u001b[?25h\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
-      "tensorflow 2.15.0 requires keras<2.16,>=2.15.0, but you have keras 3.0.2 which is incompatible.\u001b[0m\u001b[31m\n",
-      "\u001b[0m"
-     ]
-    }
-   ],
-   "source": [
-    "!pip install -q git+https://github.com/divyashreepathihalli/keras-cv.git@CLIP_refactor\n",
-    "!pip install -q keras-nlp\n",
-    "!pip install -q tf-keras\n",
-    "!pip install -q tensorflow-text\n",
-    "!pip install -q keras==3.0.2"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "nuFgha2jTshi",
-    "outputId": "63d4160e-42b3-4f6b-e672-ba30c9402d25"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "--2024-02-21 20:54:06--  https://i.imgur.com/8H7XCH0.jpg\n",
-      "Resolving i.imgur.com (i.imgur.com)... 146.75.76.193\n",
-      "Connecting to i.imgur.com (i.imgur.com)|146.75.76.193|:443... connected.\n",
-      "HTTP request sent, awaiting response... 200 OK\n",
-      "Length: 44544 (44K) [image/jpeg]\n",
-      "Saving to: ‘cat.jpg’\n",
-      "\n",
-      "\rcat.jpg               0%[                    ]       0  --.-KB/s               \rcat.jpg             100%[===================>]  43.50K  --.-KB/s    in 0.01s   \n",
-      "\n",
-      "2024-02-21 20:54:06 (4.16 MB/s) - ‘cat.jpg’ saved [44544/44544]\n",
-      "\n",
-      "--2024-02-21 20:54:06--  http://images.cocodataset.org/val2017/000000039769.jpg\n",
-      "Resolving images.cocodataset.org (images.cocodataset.org)... 52.217.206.137, 16.182.42.89, 54.231.201.177, ...\n",
-      "Connecting to images.cocodataset.org (images.cocodataset.org)|52.217.206.137|:80... connected.\n",
-      "HTTP request sent, awaiting response... 200 OK\n",
-      "Length: 173131 (169K) [image/jpeg]\n",
-      "Saving to: ‘two_cats.jpg’\n",
-      "\n",
-      "two_cats.jpg        100%[===================>] 169.07K  --.-KB/s    in 0.09s   \n",
-      "\n",
-      "2024-02-21 20:54:07 (1.77 MB/s) - ‘two_cats.jpg’ saved [173131/173131]\n",
-      "\n",
-      "--2024-02-21 20:54:07--  https://i.imgur.com/PpgZzP4.jpeg\n",
-      "Resolving i.imgur.com (i.imgur.com)... 146.75.76.193\n",
-      "Connecting to i.imgur.com (i.imgur.com)|146.75.76.193|:443... connected.\n",
-      "HTTP request sent, awaiting response... 200 OK\n",
-      "Length: 1610285 (1.5M) [image/jpeg]\n",
-      "Saving to: ‘mountain.jpg’\n",
-      "\n",
-      "mountain.jpg        100%[===================>]   1.54M  --.-KB/s    in 0.06s   \n",
-      "\n",
-      "2024-02-21 20:54:07 (27.6 MB/s) - ‘mountain.jpg’ saved [1610285/1610285]\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "!wget https://i.imgur.com/8H7XCH0.jpg -O cat.jpg\n",
-    "!wget http://images.cocodataset.org/val2017/000000039769.jpg -O two_cats.jpg\n",
-    "!wget https://i.imgur.com/PpgZzP4.jpeg -O mountain.jpg"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
     "id": "mdGT8Em4Mc4b"
    },
    "source": [
@@ -203,7 +100,9 @@
     "    \"CLIP_L14\": \"openai/clip-vit-large-patch14\",\n",
     "    \"CLIP_L14_336\": \"openai/clip-vit-large-patch14-336\",\n",
     "}\n",
-    "config_name = \"CLIP_L14_336\"  # @param [\"CLIP_B16\", \"CLIP_B32\", \"CLIP_L14\", \"CLIP_L14_336\"]\n",
+    "config_name = (\n",
+    "    \"CLIP_B16\"  # @param [\"CLIP_B16\", \"CLIP_B32\", \"CLIP_L14\", \"CLIP_L14_336\"]\n",
+    ")\n",
     "config_name_hf = model_map_hf[config_name]"
    ]
   },
@@ -259,232 +158,7 @@
     "id": "uE6x7gfqa3Ee",
     "outputId": "f55fc358-04a4-42ce-c397-3f81a238ab1e"
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">Model: \"clip\"</span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[1mModel: \"clip\"\u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓\n",
-       "┃<span style=\"font-weight: bold\"> Layer (type)                       </span>┃<span style=\"font-weight: bold\"> Output Shape                  </span>┃<span style=\"font-weight: bold\">     Param # </span>┃\n",
-       "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩\n",
-       "│ image_encoder (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">CLIPImageEncoder</span>)   │ ?                             │ <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> (unbuilt) │\n",
-       "├────────────────────────────────────┼───────────────────────────────┼─────────────┤\n",
-       "│ text_encoder (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">CLIPTextEncoder</span>)     │ ?                             │ <span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> (unbuilt) │\n",
-       "└────────────────────────────────────┴───────────────────────────────┴─────────────┘\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓\n",
-       "┃\u001b[1m \u001b[0m\u001b[1mLayer (type)                      \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mOutput Shape                 \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1m    Param #\u001b[0m\u001b[1m \u001b[0m┃\n",
-       "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩\n",
-       "│ image_encoder (\u001b[38;5;33mCLIPImageEncoder\u001b[0m)   │ ?                             │ \u001b[38;5;34m0\u001b[0m (unbuilt) │\n",
-       "├────────────────────────────────────┼───────────────────────────────┼─────────────┤\n",
-       "│ text_encoder (\u001b[38;5;33mCLIPTextEncoder\u001b[0m)     │ ?                             │ \u001b[38;5;34m0\u001b[0m (unbuilt) │\n",
-       "└────────────────────────────────────┴───────────────────────────────┴─────────────┘\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Total params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">1</span> (4.00 B)\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[1m Total params: \u001b[0m\u001b[38;5;34m1\u001b[0m (4.00 B)\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Trainable params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">1</span> (4.00 B)\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[1m Trainable params: \u001b[0m\u001b[38;5;34m1\u001b[0m (4.00 B)\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Non-trainable params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> (0.00 B)\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[1m Non-trainable params: \u001b[0m\u001b[38;5;34m0\u001b[0m (0.00 B)\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "model.summary()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "buXKlNfGTenW"
-   },
    "outputs": [],
-   "source": [
-    "processor = CLIPProcessor(\n",
-    "    MODEL_CONFIGS[config_name][\"image_resolution\"], \"vocab.json\", \"merges.txt\"\n",
-    ")\n",
-    "image = processor.process_images([\"two_cats.jpg\"])\n",
-    "text_input = [\"mountains\", \"cat on tortoise\", \"two cats\"]\n",
-    "text, attention_mask = processor.process_texts(text_input)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "BHSpMv0PT5SX"
-   },
-   "outputs": [],
-   "source": [
-    "image_logits, text_logits = model(image, text, attention_mask)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "JPn0gACJjKy5",
-    "outputId": "cbc7313a-4ddd-4021-9e84-fa668987849d"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "tensor([[3.7318, 3.7792, 3.7633]], grad_fn=<MulBackward0>)"
-      ]
-     },
-     "execution_count": 32,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "image_logits"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 193
-    },
-    "id": "GgNBvYCTtmA3",
-    "outputId": "a667a9e5-397e-4299-fdc1-8899621112ad"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\">Model: \"clip\"</span>\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[1mModel: \"clip\"\u001b[0m\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓\n",
-       "┃<span style=\"font-weight: bold\"> Layer (type)                       </span>┃<span style=\"font-weight: bold\"> Output Shape                  </span>┃<span style=\"font-weight: bold\">     Param # </span>┃\n",
-       "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩\n",
-       "│ image_encoder (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">CLIPImageEncoder</span>)   │ ?                             │ <span style=\"color: #00af00; text-decoration-color: #00af00\">304,293,888</span> │\n",
-       "├────────────────────────────────────┼───────────────────────────────┼─────────────┤\n",
-       "│ text_encoder (<span style=\"color: #0087ff; text-decoration-color: #0087ff\">CLIPTextEncoder</span>)     │ ?                             │ <span style=\"color: #00af00; text-decoration-color: #00af00\">123,650,304</span> │\n",
-       "└────────────────────────────────────┴───────────────────────────────┴─────────────┘\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓\n",
-       "┃\u001b[1m \u001b[0m\u001b[1mLayer (type)                      \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1mOutput Shape                 \u001b[0m\u001b[1m \u001b[0m┃\u001b[1m \u001b[0m\u001b[1m    Param #\u001b[0m\u001b[1m \u001b[0m┃\n",
-       "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩\n",
-       "│ image_encoder (\u001b[38;5;33mCLIPImageEncoder\u001b[0m)   │ ?                             │ \u001b[38;5;34m304,293,888\u001b[0m │\n",
-       "├────────────────────────────────────┼───────────────────────────────┼─────────────┤\n",
-       "│ text_encoder (\u001b[38;5;33mCLIPTextEncoder\u001b[0m)     │ ?                             │ \u001b[38;5;34m123,650,304\u001b[0m │\n",
-       "└────────────────────────────────────┴───────────────────────────────┴─────────────┘\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Total params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">427,944,193</span> (1.59 GB)\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[1m Total params: \u001b[0m\u001b[38;5;34m427,944,193\u001b[0m (1.59 GB)\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Trainable params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">427,944,193</span> (1.59 GB)\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[1m Trainable params: \u001b[0m\u001b[38;5;34m427,944,193\u001b[0m (1.59 GB)\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-weight: bold\"> Non-trainable params: </span><span style=\"color: #00af00; text-decoration-color: #00af00\">0</span> (0.00 B)\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "\u001b[1m Non-trainable params: \u001b[0m\u001b[38;5;34m0\u001b[0m (0.00 B)\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
    "source": [
     "model.summary()"
    ]
@@ -614,190 +288,10 @@
     "id": "EntuvOq1MhwU",
     "outputId": "cbd7cd77-6d8f-4a76-dae0-24530c12eeb6"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/local/lib/python3.10/dist-packages/huggingface_hub/utils/_token.py:88: UserWarning: \n",
-      "The secret `HF_TOKEN` does not exist in your Colab secrets.\n",
-      "To authenticate with the Hugging Face Hub, create a token in your settings tab (https://huggingface.co/settings/tokens), set it as secret in your Google Colab and restart your session.\n",
-      "You will be able to reuse this secret in all of your notebooks.\n",
-      "Please note that authentication is recommended but still optional to access public models or datasets.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "46636db47838400cb7407fc2ab0720eb",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "config.json:   0%|          | 0.00/4.76k [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f359ba8ef0cf4841b40acafcd770480c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "pytorch_model.bin:   0%|          | 0.00/1.71G [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/local/lib/python3.10/dist-packages/torch/_utils.py:831: UserWarning: TypedStorage is deprecated. It will be removed in the future and UntypedStorage will be the only storage class. This should only matter to you if you are using storages directly.  To access UntypedStorage directly, use tensor.untyped_storage() instead of tensor.storage()\n",
-      "  return self.fget.__get__(instance, owner)()\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3af19b8b653c4b21a65f7e96dd463aac",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "preprocessor_config.json:   0%|          | 0.00/316 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5c21455d9faa4112ba6f18819f7ef038",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "tokenizer_config.json:   0%|          | 0.00/844 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "418143d2ad92458094259dfca0a747cc",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "vocab.json:   0%|          | 0.00/862k [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c06b5a6588eb42189210d1c20ccba87a",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "merges.txt:   0%|          | 0.00/525k [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "79020bd42626472a85bf9047d014830f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "tokenizer.json:   0%|          | 0.00/2.22M [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ec7bc6e82f2042b8b29a6f21e6db1709",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "special_tokens_map.json:   0%|          | 0.00/389 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "model_hf = CM.from_pretrained(config_name_hf)\n",
     "processor_hf = CP.from_pretrained(config_name_hf)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/"
-    },
-    "id": "Ep8DRTkv3AwS",
-    "outputId": "6e3e802c-3db6-48ac-e3ab-4f52416449a8"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "tensor([[11.7865, 31.2010, 11.9718]], grad_fn=<TBackward0>)"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "import torch\n",
-    "import numpy as np\n",
-    "\n",
-    "photo = {\n",
-    "    \"cat\": \"https://i.imgur.com/8H7XCH0.jpg\",\n",
-    "    \"two_cats\": \"http://images.cocodataset.org/val2017/000000039769.jpg\",\n",
-    "    \"mountain\": \"https://i.imgur.com/PpgZzP4.jpeg\",\n",
-    "}\n",
-    "url = photo[\"cat\"]\n",
-    "image_hf = Image.open(requests.get(url, stream=True).raw)\n",
-    "text_inputs = [\"mountains\", \"cat on tortoise\", \"two dogs\"]\n",
-    "inputs = processor_hf(\n",
-    "    text=text_inputs, images=image_hf, return_tensors=\"pt\", padding=True\n",
-    ")\n",
-    "outputs = model_hf(**inputs)\n",
-    "logits_per_image = (\n",
-    "    outputs.logits_per_image\n",
-    ")  # this is the image-text similarity score\n",
-    "probs = logits_per_image.softmax(\n",
-    "    dim=1\n",
-    ")  # we can take the softmax to get the label probabilitiesprobs\n",
-    "logits_per_image"
    ]
   },
   {
@@ -827,7 +321,7 @@
     "id": "TUCpKltRG4Gd"
    },
    "source": [
-    "##vision encoder"
+    "## Vision Encoder"
    ]
   },
   {
@@ -838,7 +332,9 @@
    },
    "outputs": [],
    "source": [
-    "model.logit_scale.assign(hf_wts.pop(\"logit_scale\").numpy())\n",
+    "model.get_layer(\"clip_head\").logit_scale.assign(\n",
+    "    hf_wts.pop(\"logit_scale\").numpy()\n",
+    ")\n",
     "model.get_layer(\"image_encoder\").get_layer(\n",
     "    \"clip_patch_embedding\"\n",
     ").class_embedding.assign(\n",
@@ -1112,18 +608,7 @@
     "id": "Bgen7hxCCeZ7",
     "outputId": "e706ca82-d292-4868-9215-d8c160b3736c"
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "odict_keys([])"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# verify that we copied all weights\n",
     "hf_wts.keys()"
@@ -1148,6 +633,13 @@
    "source": [
     "model.save_weights(\"model.weights.h5\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -1158,11 +650,21 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
    "name": "python3"
   },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
@@ -3906,5 +3408,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
This PR updates CLIP to use the functional way of writing models in Keras.

It's currently a rough patch since I worked on it a few weeks ago. Will have to polish the overall diff and make sure I am not toughing the numerics.

Refactor includes:

- CLIPProcessor is now a Keras layer and uses some utilities from KerasNLP to support all types of python types and array inputs
- CLIPImageEncoder, CLIPTextEncoder, and CLIPEncoder now implement a `.compute_output_shape` method (required for CLIP to work with the functional API)
- CLIPHead added to remove raw variables from the CLIP Task models; having variables in `keras.Model` class is tricky since functional API doesn't allow state.
- CLIP checkpointing script has been updated to now work with the new API: new weights will be uploaded to Kaggle.

TODO: attribute KerasNLP wherever relevant
TODO: upload new weights to Kaggle
TODO: refactor the CLIPProcessor class and the CLIP class to also pull tokenizer vocab and merges from Kaggle.

@divyashreepathihalli 
